### PR TITLE
Limit number of saved checkpoints and states

### DIFF
--- a/codes/train.py
+++ b/codes/train.py
@@ -266,11 +266,23 @@ class Trainer:
                     self.logger.info('Saving models and training states.')
                 else:
                     self.logger.info('Saving model.')
-                if opt['upgrades']['number_of_checkpoints_to_save'] > 0:
+
+                if opt['upgrades']['number_of_checkpoints_to_save'] > 0 or \
+                        opt['upgrades']['number_of_states_to_save'] > 0:
+
+                    number_of_states_to_save = opt['upgrades']['number_of_states_to_save'] \
+                        if not opt['logger']['disable_state_saving'] else 0
+
                     self.logger.info(
-                        f"Leaving only {opt['upgrades']['number_of_checkpoints_to_save']} checkpoints/states"
+                        f"Leaving only {opt['upgrades']['number_of_checkpoints_to_save']} checkpoints and "
+                        f"{number_of_states_to_save} states"
                     )
-                    self.model.leave_number_of_checkpoints(next(iter(opt['networks'].keys())),opt['upgrades']['number_of_checkpoints_to_save'])
+                    self.model.limit_number_of_checkpoints_and_states(
+                        next(iter(opt['networks'].keys())),
+                        models_number=opt['upgrades']['number_of_checkpoints_to_save'],
+                        state_number=opt['upgrades']['number_of_states_to_save'],
+                    )
+
                 self.model.save(self.current_step)
                 state = {'epoch': self.epoch, 'iter': self.current_step, 'total_data_processed': self.total_training_data_encountered}
                 if self.dataset_debugger is not None:

--- a/codes/utils/BASE_gpt.yaml
+++ b/codes/utils/BASE_gpt.yaml
@@ -148,10 +148,21 @@ logger:
   disable_state_saving: true
 upgrades:
   # Variable: number_of_checkpoints_to_save
-  # Description: Define how many checkpoints should be saved on disk (1 checkpoint + 1 state =~ 6.8 GB)
+  # Description: Define how many checkpoints should be saved on disk (1 checkpoint = pth+ =~ 6.8 GB)
   # Type: integer
-  # Values:
-  # smaller than 1 - turn off this option; there is no max value. For Colab use 1 or 2.
+  # Value: should be the same value as for number_of_states_to_save
+  # smaller than 1 - turn off this option; there is no max value.
+  # For Colab use 1 or 2 for gDrive and 5 for instance drive
   # 1 == Leave last saved checkpoint + last saved state (about 6.8 GB).
   # 2 == Leave last 2 saved checkpoints + last saved states (about 2 *~ 6.8 GB =~ 13.6 GB).
   number_of_checkpoints_to_save: 0
+  # Variable: number_of_states_to_save
+  # Description: Define how many states should be saved on disk (1 state =~ 3.4 GB)
+  # if disable_state_saving is set as true this option will be inactive
+  # Type: integer
+  # Value: should be the same value as for number_of_checkpoints_to_save
+  # smaller than 1 - turn off this option; there is no max value.
+  # For Colab use 1 or 2 for gDrive and 5 for instance drive
+  # 1 == Leave last saved state (about 3.4 GB).
+  # 2 == Leave last 2 saved states (about 2 *~ 3.4 GB =~ 6.8 GB).
+  number_of_states_to_save: 0

--- a/experiments/EXAMPLE_diff.yml
+++ b/experiments/EXAMPLE_diff.yml
@@ -216,10 +216,21 @@ logger:
 
 upgrades:
   # Variable: number_of_checkpoints_to_save
-  # Description: Define how many checkpoints should be saved on disk (1 checkpoint + 1 state =~ 6.8 GB)
+  # Description: Define how many checkpoints should be saved on disk (1 checkpoint = pth+ =~ 6.8 GB)
   # Type: integer
-  # Values:
+  # Value: should be the same value as for number_of_states_to_save
   # smaller than 1 - turn off this option; there is no max value. For Colab use 1 or 2.
+  # For Colab use 1 or 2 for gDrive and 5 for instance drive
   # 1 == Leave last saved checkpoint + last saved state (about 6.8 GB).
   # 2 == Leave last 2 saved checkpoints + last saved states (about 2 *~ 6.8 GB =~ 13.6 GB).
   number_of_checkpoints_to_save: 0
+  # Variable: number_of_states_to_save
+  # Description: Define how many states should be saved on disk (1 state =~ 3.4 GB)
+  # if disable_state_saving is set as true this option will be inactive
+  # Type: integer
+  # Value: should be the same value as for number_of_checkpoints_to_save
+  # smaller than 1 - turn off this option; there is no max value.
+  # For Colab use 1 or 2 for gDrive and 5 for instance drive
+  # 1 == Leave last saved state (about 3.4 GB).
+  # 2 == Leave last 2 saved states (about 2 *~ 3.4 GB =~ 6.8 GB).
+  number_of_states_to_save: 0

--- a/experiments/EXAMPLE_gpt.yml
+++ b/experiments/EXAMPLE_gpt.yml
@@ -144,10 +144,21 @@ logger:
 
 upgrades:
   # Variable: number_of_checkpoints_to_save
-  # Description: Define how many checkpoints should be saved on disk (1 checkpoint + 1 state =~ 6.8 GB)
+  # Description: Define how many checkpoints should be saved on disk (1 checkpoint = pth+ =~ 6.8 GB)
   # Type: integer
-  # Values:
+  # Value: should be the same value as for number_of_states_to_save
   # smaller than 1 - turn off this option; there is no max value. For Colab use 1 or 2.
+  # For Colab use 1 or 2 for gDrive and 5 for instance drive
   # 1 == Leave last saved checkpoint + last saved state (about 6.8 GB).
   # 2 == Leave last 2 saved checkpoints + last saved states (about 2 *~ 6.8 GB =~ 13.6 GB).
   number_of_checkpoints_to_save: 0
+  # Variable: number_of_states_to_save
+  # Description: Define how many states should be saved on disk (1 state =~ 3.4 GB)
+  # if disable_state_saving is set as true this option will be inactive
+  # Type: integer
+  # Value: should be the same value as for number_of_checkpoints_to_save
+  # smaller than 1 - turn off this option; there is no max value.
+  # For Colab use 1 or 2 for gDrive and 5 for instance drive
+  # 1 == Leave last saved state (about 3.4 GB).
+  # 2 == Leave last 2 saved states (about 2 *~ 3.4 GB =~ 6.8 GB).
+  number_of_states_to_save: 0


### PR DESCRIPTION
Renamed method to limit_number_of_checkpoints_and_states
Now we can specify number of models and number of states to save.